### PR TITLE
fix panic in a filter expression without parentheses

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -251,12 +251,14 @@ func parse_token(token string) (op string, key string, args interface{}, err err
 		tail = tail[1 : len(tail)-1]
 
 		//fmt.Println(key, tail)
-		if strings.Contains(tail, "?") {
+		if strings.HasPrefix(tail, "?") {
 			// filter -------------------------------------------------
 			op = "filter"
-			if strings.HasPrefix(tail, "?(") && strings.HasSuffix(tail, ")") {
-				args = strings.Trim(tail[2:len(tail)-1], " ")
+			if !strings.HasPrefix(tail, "?(") || !strings.HasSuffix(tail, ")") {
+				err = fmt.Errorf("filter expression needs to be enclosed in parentheses: %v", tail)
+				return
 			}
+			args = strings.Trim(tail[2:len(tail)-1], " ")
 			return
 		} else if strings.Contains(tail, ":") {
 			// range ----------------------------------------------

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -318,6 +318,37 @@ func Test_jsonpath_JsonPathLookup_filter(t *testing.T) {
 			}
 		}
 	}
+
+	res, err = JsonPathLookup(json_data, "$.store.book[?@.isbn)]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
+	res, err = JsonPathLookup(json_data, "$.store.book[?(@.isbn]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
+	res, err = JsonPathLookup(json_data, "$.store.book[?@.isbn]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
+	res, err = JsonPathLookup(json_data, "$.store.book[? (@.isbn)]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
+	res, err = JsonPathLookup(json_data, "$.store.book[ ?(@.isbn)]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
 }
 
 func Test_jsonpath_JsonPathLookup_struct_filter(t *testing.T) {
@@ -381,6 +412,37 @@ func Test_jsonpath_JsonPathLookup_struct_filter(t *testing.T) {
 			}
 		}
 	}
+
+	res, err = JsonPathLookup(structData, "$.store.book[?@.isbn)]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
+	res, err = JsonPathLookup(structData, "$.store.book[?(@.isbn]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
+	res, err = JsonPathLookup(structData, "$.store.book[?@.isbn]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
+	res, err = JsonPathLookup(structData, "$.store.book[? (@.isbn)]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
+	res, err = JsonPathLookup(structData, "$.store.book[ ?(@.isbn)]")
+	t.Log(err, res)
+	if _, ok := res.([]interface{}); ok == true {
+		t.Errorf("expected: error, received: %v", res)
+	}
+
 }
 
 func Test_jsonpath_authors_of_all_books(t *testing.T) {


### PR DESCRIPTION
Before this fix, it had a panic in a filter expression without parentheses.