### PR TITLE
issue1 : Panic on filter query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/AsaiYusuke/jsonpath
 
 go 1.15
-
-require github.com/pointlander/peg v1.0.1 // indirect

--- a/syntax_basic_compare_query.go
+++ b/syntax_basic_compare_query.go
@@ -29,25 +29,12 @@ func (q *syntaxBasicCompareQuery) compute(
 			return rightValues
 		}
 
-		if q.rightParam.isLiteral {
-			for leftIndex := range leftValues {
-				if _, ok := leftValues[leftIndex].(struct{}); ok {
-					continue
-				}
-
-				if !q.comparator.comparator(leftValues[leftIndex], rightValues[0]) {
-					leftValues[leftIndex] = struct{}{}
-				}
-			}
-			return leftValues
-		}
-
 		for leftIndex := range leftValues {
 			if _, ok := leftValues[leftIndex].(struct{}); ok {
 				continue
 			}
 
-			if !q.comparator.comparator(leftValues[leftIndex], rightValues[leftIndex]) {
+			if !q.comparator.comparator(leftValues[leftIndex], rightValues[0]) {
 				leftValues[leftIndex] = struct{}{}
 			}
 		}

--- a/syntax_query_logical_and.go
+++ b/syntax_query_logical_and.go
@@ -10,6 +10,24 @@ func (l *syntaxLogicalAnd) compute(
 
 	leftComputedList := l.leftQuery.compute(root, currentList, container)
 	rightComputedList := l.rightQuery.compute(root, currentList, container)
+	if len(leftComputedList) == 1 {
+		if _, ok := leftComputedList[0].(struct{}); ok {
+			for index := range rightComputedList {
+				rightComputedList[index] = struct{}{}
+			}
+		}
+		return rightComputedList
+	}
+
+	if len(rightComputedList) == 1 {
+		if _, ok := rightComputedList[0].(struct{}); ok {
+			for index := range leftComputedList {
+				leftComputedList[index] = struct{}{}
+			}
+		}
+		return leftComputedList
+	}
+
 	for index := range leftComputedList {
 		if _, ok := rightComputedList[index].(struct{}); ok {
 			leftComputedList[index] = struct{}{}

--- a/syntax_query_logical_or.go
+++ b/syntax_query_logical_or.go
@@ -10,8 +10,26 @@ func (l *syntaxLogicalOr) compute(
 
 	leftComputedList := l.leftQuery.compute(root, currentList, container)
 	rightComputedList := l.rightQuery.compute(root, currentList, container)
-	for index := range rightComputedList {
-		if _, ok := leftComputedList[index].(struct{}); ok {
+	if len(leftComputedList) == 1 {
+		if _, ok := leftComputedList[0].(struct{}); !ok {
+			for index := range rightComputedList {
+				rightComputedList[index] = leftComputedList[0]
+			}
+		}
+		return rightComputedList
+	}
+
+	if len(rightComputedList) == 1 {
+		if _, ok := rightComputedList[0].(struct{}); !ok {
+			for index := range leftComputedList {
+				leftComputedList[index] = rightComputedList[0]
+			}
+		}
+		return leftComputedList
+	}
+
+	for index := range leftComputedList {
+		if _, ok := rightComputedList[index].(struct{}); !ok {
 			leftComputedList[index] = rightComputedList[index]
 		}
 	}

--- a/test_jsonpath_test.go
+++ b/test_jsonpath_test.go
@@ -4148,6 +4148,26 @@ func TestRetrieve_filterLogicalCombination(t *testing.T) {
 				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
 				expectedJSON: `[{"a":1},{"a":3}]`,
 			},
+			{
+				jsonpath:     `$[?((1==2) || @.a>1)]`,
+				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
+				expectedJSON: `[{"a":2},{"a":3}]`,
+			},
+			{
+				jsonpath:     `$[?((1==1) || @.a>1)]`,
+				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
+				expectedJSON: `[{"a":1},{"a":2},{"a":3}]`,
+			},
+			{
+				jsonpath:     `$[?(@.a>1 || (1==2))]`,
+				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
+				expectedJSON: `[{"a":2},{"a":3}]`,
+			},
+			{
+				jsonpath:     `$[?(@.a>1 || (1==1))]`,
+				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
+				expectedJSON: `[{"a":1},{"a":2},{"a":3}]`,
+			},
 		},
 		`logical AND`: []TestCase{
 			{
@@ -4164,6 +4184,28 @@ func TestRetrieve_filterLogicalCombination(t *testing.T) {
 				jsonpath:     `$[?(@.a<3 && @.a>1)]`,
 				inputJSON:    `[{"a":1},{"a":1.1},{"a":2.9},{"a":3}]`,
 				expectedJSON: `[{"a":1.1},{"a":2.9}]`,
+			},
+			{
+				jsonpath:     `$[?((1==2) && @.a>1)]`,
+				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
+				expectedJSON: `[]`,
+				expectedErr:  createErrorMemberNotExist(`[?((1==2) && @.a>1)]`),
+			},
+			{
+				jsonpath:     `$[?((1==1) && @.a>1)]`,
+				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
+				expectedJSON: `[{"a":2},{"a":3}]`,
+			},
+			{
+				jsonpath:     `$[?(@.a>1 && (1==2))]`,
+				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
+				expectedJSON: `[]`,
+				expectedErr:  createErrorMemberNotExist(`[?(@.a>1 && (1==2))]`),
+			},
+			{
+				jsonpath:     `$[?(@.a>1 && (1==1))]`,
+				inputJSON:    `[{"a":1},{"a":2},{"a":3}]`,
+				expectedJSON: `[{"a":2},{"a":3}]`,
 			},
 		},
 		`logical NOT`: []TestCase{


### PR DESCRIPTION
Issue #1 

Fixed a problem that caused abnormal termination for logical AND/OR operations involving literals during filtering.

```
$[?(@.a>1 && (1==2))]
```
